### PR TITLE
NaN results

### DIFF
--- a/matrix.go
+++ b/matrix.go
@@ -1,6 +1,10 @@
 package fauxgl
 
-import "math"
+import (
+	"math"
+
+	"github.com/beorn7/floats"
+)
 
 type Matrix struct {
 	X00, X01, X02, X03 float64
@@ -47,9 +51,11 @@ func Rotate(v Vector, a float64) Matrix {
 
 func RotateTo(a, b Vector) Matrix {
 	dot := b.Dot(a)
-	if dot == 1 {
+	// To avoid occasional NaN results
+	// TODO: epsilon might be an input or ...
+	if floats.AlmostEqual(dot, 1, .0001) {
 		return Identity()
-	} else if dot == -1 {
+	} else if floats.AlmostEqual(dot, -1, .0001) {
 		return Rotate(a.Perpendicular(), math.Pi)
 	} else {
 		angle := math.Acos(dot)


### PR DESCRIPTION
### Observation

Occasional `NaN` results are observed. For example when `up` input for `Orient` is:

![image](https://user-images.githubusercontent.com/17475482/82118336-f7b05c00-978b-11ea-9b49-5219ed330626.png)

or:

![image](https://user-images.githubusercontent.com/17475482/82118343-05fe7800-978c-11ea-9f01-8145b6cae6bf.png)

Inside `func RotateTo(a, b Vector)`, the statement `v := b.Cross(a).Normalize()` result is:

![image](https://user-images.githubusercontent.com/17475482/82118413-90df7280-978c-11ea-85b7-ad751afd47d0.png)


### Proposed solution

To avoid `NaN` results, approximate float comparison is done by [this package](https://godoc.org/github.com/beorn7/floats). Having done so, the `NaN` results are no loner observed.