### PR TITLE
Fix bug where rasterize() hangs on Apple silicon

### DIFF
--- a/context.go
+++ b/context.go
@@ -195,6 +195,9 @@ func (dc *Context) rasterize(v0, v1, v2 Vertex, s0, s1, s2 Vector) RasterizeInfo
 		if w02 < 0 && d2 > d {
 			d = d2
 		}
+		if d == math.Inf(1) {
+			d = 0
+		}
 		d = float64(int(d))
 		if d < 0 {
 			// occurs in pathological cases


### PR DESCRIPTION
Hi,

Thanks for writing fauxgl, I've found it very useful. I ran into a problem when running my project on an Apple silicon laptop. Please consider this patch which fixes the problem.

If any edges of the triangle are horizontal or vertical, it's possible
for the raXX variables, and thus d, to get a division by zero leading
to +Inf. On Intel, when +Inf is converted to int and back with
  d = float64(int(d))
the result is a very large negative number which the existing check
converts to zero. On ARM (or at least on Apple Silicon which is where I
ran into the problem) the result is a very large positive number,
causing the function to hang.

You can verify this with the following small fragment of code:
	var one float64 = 1
	var zero float64 = 0
	var divZero float64 = one / zero
	var castAndCastBack = float64(int(divZero))
	fmt.Printf("%f\n", castAndCastBack)
On an Intel CPU that will print a very large negative number, on Apple silicon a very large positive number.